### PR TITLE
runner: Use multiple browser contexts to speed up testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Every project must have a configuration file:
 
     // Width of the screenshot capture. Must match the image reference width.
     "width": 480,
-    // Height of the screenshot capture. Must match the image reference width.
+    // Height of the screenshot capture. Must match the image reference height.
     "height": 270,
 
     "scenarios": [

--- a/README.md
+++ b/README.md
@@ -90,6 +90,11 @@ Every project must have a configuration file:
     // If this timeout is reached, the test suite will fail.
     "timeout": 60000,
 
+    // Width of the screenshot capture. Must match the image reference width.
+    "width": 480,
+    // Height of the screenshot capture. Must match the image reference width.
+    "height": 270,
+
     "scenarios": [
         {
             // Default loading event: Wait for `MyScene.bin` to load
@@ -176,5 +181,3 @@ In watch mode, the browser will automatically open and the tests will block when
 |**-o, --output**|_Path_|Output folder for saved screenshots. References overwritten by default|
 |**-w, --watch**|_String_|Event to watch, i.e., to freeze the runner on|
 |**--logs**|_Path_|Path to store the browser logs. If not provided, logs will be discarded|
-|**--width**|_Number_|Overriding screenshot width|
-|**--height**|_Number_|Overriding screenshot height|

--- a/dist/cli.js
+++ b/dist/cli.js
@@ -19,9 +19,9 @@ function printHelp(summary = false) {
     console.log(`USAGE: ${COMMAND_NAME} <PATH>`);
     console.log('\nOPTIONS:');
     console.log('\t-o, --output:\tScreenshot output folder. Overwrites references by default\n' +
-        '\t--logs:\tPath to save the browser logs. Logs will be discarded if not provided\n' +
-        '\t--width:\tOverriding screenshot width\n' +
-        '\t--height:\tOverriding screenshot height\n');
+        '\t--mode:\tCapture and compare (`capture-and-compare`), or capture only (`capture`)\n' +
+        '\t--max-contexts:\tMaximum number of parralel browser instances. Up to one per project.\n' +
+        '\t--logs:\tPath to save the browser logs. Logs will be discarded if not provided\n');
     console.log('\nFLAGS:');
     console.log('\t-h, --help:\tPrints help\n' +
         '\t-w, --watch:\tStart the runner in watch mode for debugging\n' +
@@ -41,9 +41,8 @@ try {
             output: { type: 'string', short: 'o' },
             save: { type: 'boolean', short: 's' },
             logs: { type: 'string' },
-            width: { type: 'string' },
-            height: { type: 'string' },
             mode: { type: 'string', default: 'capture-and-compare' },
+            'max-contexts': { type: 'string' },
             'save-on-failure': { type: 'boolean' },
         },
         allowPositionals: true,
@@ -58,6 +57,7 @@ if (args.help) {
     printHelp();
     process.exit(0);
 }
+const maxContexts = args['max-contexts'] ? parseInt(args['max-contexts']) : null;
 const config = new Config();
 config.watch = args.watch ?? null;
 config.output = args.output ? resolve(args.output) : null;
@@ -65,17 +65,7 @@ config.save = args['save-on-failure'] ? SaveMode.OnFailure : SaveMode.None;
 config.save = args.save ? SaveMode.All : config.save;
 config.mode =
     args.mode === 'capture-and-compare' ? RunnerMode.CaptureAndCompare : RunnerMode.Capture;
-try {
-    const width = args.width ? parseInt(args.width) : null;
-    const height = args.height ? parseInt(args.height) : null;
-    if (width)
-        config.width = width;
-    if (height)
-        config.height = height;
-}
-catch (e) {
-    logErrorExit('--width and --height must be integers');
-}
+config.maxContexts = maxContexts && !isNaN(maxContexts) ? maxContexts : null;
 try {
     await config.load(positionals[0] ?? CONFIG_NAME);
 }

--- a/dist/config.d.ts
+++ b/dist/config.d.ts
@@ -40,6 +40,10 @@ export interface Project {
     path: string;
     name: string;
     timeout: number;
+    /** Screenshot width. Defaults to **480**. */
+    width: number;
+    /** Screenshot height. Defaults to **270**. */
+    height: number;
     scenarios: Scenario[];
 }
 /**
@@ -62,16 +66,14 @@ export declare class Config {
     mode: RunnerMode;
     /** Whether to save the screenshots or not.  */
     save: SaveMode;
-    /** Overriding screenshot width. */
-    width: number | null;
-    /** Overriding screenshot height. */
-    height: number | null;
     /** Web server port. */
     port: number;
     /** Event to watch. If `null`, watching is disabled. */
     watch: string | null;
     /** Browser logs setup. */
     log: LogLevel;
+    /** Maximum number of browser contexts running simultaneously. */
+    maxContexts: number | null;
     load(path: string): Promise<void>;
     /**
      * Append a configuration.

--- a/dist/config.js
+++ b/dist/config.js
@@ -70,16 +70,14 @@ export class Config {
     mode = RunnerMode.CaptureAndCompare;
     /** Whether to save the screenshots or not.  */
     save = SaveMode.None;
-    /** Overriding screenshot width. */
-    width = null;
-    /** Overriding screenshot height. */
-    height = null;
     /** Web server port. */
     port = 8080;
     /** Event to watch. If `null`, watching is disabled. */
     watch = null;
     /** Browser logs setup. */
     log = LogLevel.Warn & LogLevel.Error;
+    /** Maximum number of browser contexts running simultaneously. */
+    maxContexts = null;
     async load(path) {
         /* Find all config files to run. */
         const isDirectory = (await stat(path)).isDirectory();
@@ -106,6 +104,8 @@ export class Config {
         const jsonScenarios = Array.isArray(json.scenarios)
             ? json.scenarios
             : [json.scenarios];
+        const width = json.width ?? 480;
+        const height = json.height ?? 270;
         const path = resolve(dirname(configPath));
         const name = basename(path);
         const scenarios = jsonScenarios.map((s) => ({
@@ -114,7 +114,7 @@ export class Config {
             tolerance: s.tolerance ?? 0.005,
             perPixelTolerance: s.perPixelTolerance ?? 0.1,
         }));
-        this.projects.push({ timeout, path, name, scenarios });
+        this.projects.push({ timeout, path, name, scenarios, width, height });
     }
     /**
      * Get the scenario associated to an event.

--- a/dist/runner.d.ts
+++ b/dist/runner.d.ts
@@ -1,6 +1,4 @@
-/// <reference types="node" resolution-mode="require"/>
-import { Browser } from 'puppeteer-core';
-import { Config, Project } from './config.js';
+import { Config } from './config.js';
 export interface Dimensions {
     width: number;
     height: number;
@@ -43,12 +41,14 @@ export declare enum LogLevel {
 export declare class ScreenshotRunner {
     /** Browser logs */
     logs: string[];
-    /** Configuration to run. @hidden */
+    /** Configuration to run. */
     private _config;
-    /** Base path to serve. @hidden */
-    private _currentBasePath;
-    /** Dispatch an info log coming from the browser. @hidden */
+    /** Browser context debounce time. */
+    private _contextDebounce;
+    /** Dispatch an info log coming from the browser. */
     private _onBrowserInfoLog;
+    /** HTTP server callback. */
+    private _httpCallback;
     /**
      * Create a new runner.
      *
@@ -69,14 +69,12 @@ export declare class ScreenshotRunner {
      */
     saveLogs(path: string): Promise<void>;
     /**
-     * Run the tests of a given project.
+     * Capture screenshots in a browser using one/multiple context(s).
      *
-     * @param project The project to run the scenarios from.
-     * @param browser Browser instance.
-     * @returns A promise that resolves to `true` if all tests passed,
-     *     `false` otherwise.
+     * @param browser The browser instance.
+     * @returns Array of screenshots **per** project.
      */
-    _runTests(project: Project, browser: Browser): Promise<boolean>;
+    private _capture;
     /**
      * Capture the screenshots for a project.
      *
@@ -85,7 +83,7 @@ export declare class ScreenshotRunner {
      * @returns An array of promise that resolve with the data for loaded images,
      *    or errors for failed images.
      */
-    _captureScreenshots(browser: Browser, project: Project, { width, height }: Dimensions): Promise<(Error | Buffer)[]>;
+    private _captureProjectScreenshots;
     /**
      * Compare screenshots against references.
      *

--- a/dist/runner.js
+++ b/dist/runner.js
@@ -1,8 +1,9 @@
 import { createServer } from 'node:http';
+import { cpus } from 'node:os';
 import { readFile, writeFile } from 'node:fs/promises';
 import { resolve, join, basename, dirname } from 'node:path';
 import { PNG } from 'pngjs';
-import { launch as puppeteerLauncher } from 'puppeteer-core';
+import { launch as puppeteerLauncher, } from 'puppeteer-core';
 import handler from 'serve-handler';
 import pixelmatch from 'pixelmatch';
 import { SaveMode, RunnerMode } from './config.js';
@@ -95,11 +96,11 @@ const LogTypeToLevel = {
 export class ScreenshotRunner {
     /** Browser logs */
     logs = [];
-    /** Configuration to run. @hidden */
+    /** Configuration to run. */
     _config;
-    /** Base path to serve. @hidden */
-    _currentBasePath = '';
-    /** Dispatch an info log coming from the browser. @hidden */
+    /** Browser context debounce time. */
+    _contextDebounce = 750;
+    /** Dispatch an info log coming from the browser. */
     _onBrowserInfoLog = (message) => {
         const msg = message.text();
         const type = message.type();
@@ -107,6 +108,16 @@ export class ScreenshotRunner {
         this.logs.push(`[${message.type()}] ${msg}`);
         if (this._config.log & level)
             console[type](`[browser] ${msg}`);
+    };
+    /** HTTP server callback. */
+    _httpCallback = (req, response) => {
+        const header = req.headers['test-project'] ?? '';
+        const projectId = parseInt(Array.isArray(header) ? header[0] : header);
+        if (isNaN(projectId))
+            return handler(req, response);
+        const project = this._config.projects[projectId];
+        const path = resolve(project.path, 'deploy');
+        return handler(req, response, { public: path });
     };
     /**
      * Create a new runner.
@@ -124,13 +135,19 @@ export class ScreenshotRunner {
     async run() {
         this.logs.length = 0;
         const config = this._config;
-        const server = createServer((request, response) => {
-            return handler(request, response, {
-                public: this._currentBasePath,
-            });
-        });
-        server.listen(config.port);
+        const projects = config.projects;
+        if (config.output)
+            await mkdirp(config.output);
+        /* Start loading references for each project */
+        const referencesPending = Array.from(config.projects, () => null);
+        for (let i = 0; i < projects.length; ++i) {
+            const project = projects[i];
+            referencesPending[i] = loadReferences(project.scenarios);
+        }
+        /* Start capturing screenshots for each project */
         console.log(`Starting test server on port: ${config.port}`);
+        const server = createServer(this._httpCallback);
+        server.listen(config.port);
         const headless = !config.watch;
         const browser = await puppeteerLauncher({
             headless,
@@ -141,22 +158,42 @@ export class ScreenshotRunner {
             waitForInitialPage: true,
             args: ['--no-sandbox', '--use-gl=angle', '--ignore-gpu-blocklist'],
         });
-        let success = true;
-        try {
-            for (const project of config.projects) {
-                /* We do not test multiple pages simultaneously to prevent
-                 * the animation loop to stop. */
-                const result = await this._runTests(project, browser);
-                success &&= result;
-            }
+        const screenshotsPending = this._capture(browser);
+        /* While we could wait simultaneously for screenshots and references, loading the pngs
+         * should be must faster and be done by now anyway. */
+        const references = await Promise.all(referencesPending);
+        const pngs = await screenshotsPending;
+        const screenshots = pngs.map((p) => p.map((s) => (s instanceof Error ? s : parsePNG(s))));
+        server.close();
+        browser.close();
+        /* Compare screenshots to references */
+        const failures = Array.from(projects, () => []);
+        for (let i = 0; i < projects.length; ++i) {
+            const { name, scenarios } = projects[i];
+            const count = scenarios.length;
+            console.log(`\n❔ Comparing ${count} scenarios in project '${name}'...`);
+            if (config.mode !== RunnerMode.CaptureAndCompare)
+                continue;
+            failures[i] = this._compare(scenarios, screenshots[i], references[i]);
         }
-        catch (e) {
-            throw e;
+        const success = failures.findIndex((a) => a.length) === -1;
+        /* Save screenshots to disk based on the config saving mode */
+        const { save } = config;
+        let toSave = [];
+        if (save === SaveMode.OnFailure) {
+            toSave = projects.map((project, i) => {
+                const failedScenarios = reduce(failures[i], project.scenarios);
+                const failedPngs = reduce(failures[i], pngs[i]);
+                return this._save(project, failedScenarios, failedPngs);
+            });
         }
-        finally {
-            server.close();
-            browser.close();
+        else {
+            toSave = projects.map((proj, i) => this._save(proj, proj.scenarios, pngs[i]));
         }
+        if (save === SaveMode.All || (save === SaveMode.OnFailure && !success)) {
+            console.log(`\n✏️  Saving scenario references...`);
+        }
+        await Promise.all(toSave);
         return success;
     }
     /**
@@ -173,46 +210,34 @@ export class ScreenshotRunner {
         return writeFile(fullpath, content);
     }
     /**
-     * Run the tests of a given project.
+     * Capture screenshots in a browser using one/multiple context(s).
      *
-     * @param project The project to run the scenarios from.
-     * @param browser Browser instance.
-     * @returns A promise that resolves to `true` if all tests passed,
-     *     `false` otherwise.
+     * @param browser The browser instance.
+     * @returns Array of screenshots **per** project.
      */
-    async _runTests(project, browser) {
-        this._currentBasePath = resolve(project.path, 'deploy');
-        const config = this._config;
-        const scenarios = project.scenarios;
-        const count = scenarios.length;
-        console.log(`\n📎 Running project ${project.name} with ${count} scenarios\n`);
-        if (config.output)
-            await mkdirp(config.output);
-        /* Load references first to validate their size. */
-        const references = await loadReferences(scenarios);
-        const first = references.find((img) => !(img instanceof Error));
-        /* Capture page screenshots upon events coming from the application. */
-        const pngs = await this._captureScreenshots(browser, project, {
-            width: config.width ?? first?.width ?? 480,
-            height: config.height ?? first?.height ?? 270,
-        });
-        const screenshots = pngs.map((s) => (s instanceof Error ? s : parsePNG(s)));
-        let failed = [];
-        if (config.mode !== RunnerMode.Capture) {
-            failed = this._compare(scenarios, screenshots, references);
-        }
-        switch (config.save) {
-            case SaveMode.OnFailure: {
-                const failedScenarios = reduce(failed, scenarios);
-                const failedPngs = reduce(failed, pngs);
-                await this._save(project, failedScenarios, failedPngs);
-                break;
+    async _capture(browser) {
+        const { projects, maxContexts } = this._config;
+        const contextsUpperBound = maxContexts ?? Math.min(Math.max(2, cpus().length), 6);
+        const contextsCount = Math.min(projects.length, contextsUpperBound);
+        console.log(`\n📷 Capturing scenarios for ${projects.length} project(s)...`);
+        console.log(`  Using ${contextsCount} browser instances`);
+        const contexts = await Promise.all(Array.from({ length: contextsCount })
+            .fill(null)
+            .map((_) => browser.createIncognitoBrowserContext()));
+        const result = Array.from(projects, () => null);
+        for (let i = 0; i < projects.length; ++i) {
+            let freeContext = -1;
+            while ((freeContext = contexts.findIndex((x) => x !== null)) === -1) {
+                /* Yield the event loop to allow checking for free contexts. */
+                await new Promise((res) => setTimeout(res, this._contextDebounce));
             }
-            case SaveMode.All:
-                await this._save(project, scenarios, pngs);
-                break;
+            const context = contexts[freeContext];
+            if (context === null)
+                throw new Error('null context');
+            contexts[freeContext] = null; /* Marks context as used */
+            result[i] = this._captureProjectScreenshots(context, i, projects[i]).finally(() => (contexts[freeContext] = context));
         }
-        return !failed.length;
+        return Promise.all(result);
     }
     /**
      * Capture the screenshots for a project.
@@ -222,8 +247,9 @@ export class ScreenshotRunner {
      * @returns An array of promise that resolve with the data for loaded images,
      *    or errors for failed images.
      */
-    async _captureScreenshots(browser, project, { width, height }) {
+    async _captureProjectScreenshots(browser, projectId, { width, height }) {
         const config = this._config;
+        const project = config.projects[projectId];
         const { scenarios, timeout } = project;
         const count = scenarios.length;
         const results = new Array(count).fill(null);
@@ -245,6 +271,9 @@ export class ScreenshotRunner {
         page.on('error', onerror);
         page.on('console', this._onBrowserInfoLog);
         page.setCacheEnabled(false);
+        page.setExtraHTTPHeaders({
+            'test-project': projectId.toString(),
+        });
         await page.setViewport({
             width: width,
             height: height,
@@ -252,14 +281,14 @@ export class ScreenshotRunner {
         });
         async function processEvent(e) {
             if (!eventToScenario.has(e)) {
-                console.warn(`❌ Received non-existing event: '${e}'`);
+                console.warn(`[${project.name}] Received non-existing event: '${e}' ❌`);
                 return;
             }
             const screenshot = await page.screenshot({
                 omitBackground: false,
                 optimizeForSpeed: false,
             });
-            console.log(`Event '${e}' received`);
+            console.log(`[${project.name}] Event '${e}' received`);
             results[eventToScenario.get(e)] = screenshot;
             /* Needs to be set after taking the screenshot to avoid
              * closing the browser too fast. */
@@ -280,7 +309,6 @@ export class ScreenshotRunner {
                 window.testScreenshot(`wle-scene-ready:${e.detail.filename}`);
             });
         });
-        console.log(`📷 Capturing scenarios...`);
         let time = 0;
         while (state === WebRunnerState.Running && eventCount < count && time < timeout) {
             const debounceTime = 1000;
@@ -299,7 +327,7 @@ export class ScreenshotRunner {
                     const errorStr = error.stack
                         ? `Stacktrace:\n${error.stack}`
                         : error + '';
-                    throw `Uncaught browser top-level error: ${errorStr}`;
+                    console.error(`[${project.name}] Uncaught browser top-level error: ${errorStr}`);
                 }
                 /* When using the watch mode, stop on any top-level error. */
                 await page.waitForNavigation();
@@ -317,7 +345,6 @@ export class ScreenshotRunner {
      * @returns An array containing indices of failed comparison.
      */
     _compare(scenarios, screenshots, references) {
-        console.log(`\n✏️  Comparing scenarios...`);
         // @todo: Move into worker
         const failed = [];
         for (let i = 0; i < screenshots.length; ++i) {
@@ -360,7 +387,6 @@ export class ScreenshotRunner {
         if (!scenarios.length)
             return;
         const config = this._config;
-        console.log(`\n✏️  Saving scenario references...`);
         let output = null;
         if (config.output) {
             const folder = basename(project.path);
@@ -381,6 +407,6 @@ export class ScreenshotRunner {
                 .then(() => console.log(`Screenshot '${summary}' saved`))
                 .catch((e) => console.log(`❌ Failed to write png '${summary}'\n  ${e.reason}`)));
         }
-        return Promise.all(promises);
+        return Promise.all(promises).then(() => { });
     }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,6 +20,8 @@ interface Arguments {
     logs?: string;
     /** Runner mode. */
     mode?: string;
+    /** Maximum number of parralel browser instances. */
+    'max-contexts'?: string;
     /** Save screenshots associated to failed tests. */
     'save-on-failure'?: boolean;
 }
@@ -46,6 +48,7 @@ function printHelp(summary = false) {
     console.log(
         '\t-o, --output:\tScreenshot output folder. Overwrites references by default\n' +
             '\t--mode:\tCapture and compare (`capture-and-compare`), or capture only (`capture`)\n' +
+            '\t--max-contexts:\tMaximum number of parralel browser instances. Up to one per project.\n' +
             '\t--logs:\tPath to save the browser logs. Logs will be discarded if not provided\n'
     );
 
@@ -74,6 +77,7 @@ try {
             save: {type: 'boolean', short: 's'},
             logs: {type: 'string'},
             mode: {type: 'string', default: 'capture-and-compare'},
+            'max-contexts': {type: 'string'},
             'save-on-failure': {type: 'boolean'},
         },
         allowPositionals: true,
@@ -89,6 +93,8 @@ if (args.help) {
     process.exit(0);
 }
 
+const maxContexts = args['max-contexts'] ? parseInt(args['max-contexts']) : null;
+
 const config = new Config();
 config.watch = args.watch ?? null;
 config.output = args.output ? resolve(args.output) : null;
@@ -96,6 +102,7 @@ config.save = args['save-on-failure'] ? SaveMode.OnFailure : SaveMode.None;
 config.save = args.save ? SaveMode.All : config.save;
 config.mode =
     args.mode === 'capture-and-compare' ? RunnerMode.CaptureAndCompare : RunnerMode.Capture;
+config.maxContexts = maxContexts && !isNaN(maxContexts) ? maxContexts : null;
 
 try {
     await config.load(positionals[0] ?? CONFIG_NAME);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,10 +18,6 @@ interface Arguments {
     save?: boolean;
     /** Path to store the logs. */
     logs?: string;
-    /** Overriding screenshot width. */
-    width?: string;
-    /** Overriding screenshot height. */
-    height?: string;
     /** Runner mode. */
     mode?: string;
     /** Save screenshots associated to failed tests. */
@@ -49,9 +45,8 @@ function printHelp(summary = false) {
     console.log('\nOPTIONS:');
     console.log(
         '\t-o, --output:\tScreenshot output folder. Overwrites references by default\n' +
-            '\t--logs:\tPath to save the browser logs. Logs will be discarded if not provided\n' +
-            '\t--width:\tOverriding screenshot width\n' +
-            '\t--height:\tOverriding screenshot height\n'
+            '\t--mode:\tCapture and compare (`capture-and-compare`), or capture only (`capture`)\n' +
+            '\t--logs:\tPath to save the browser logs. Logs will be discarded if not provided\n'
     );
 
     console.log('\nFLAGS:');
@@ -78,8 +73,6 @@ try {
             output: {type: 'string', short: 'o'},
             save: {type: 'boolean', short: 's'},
             logs: {type: 'string'},
-            width: {type: 'string'},
-            height: {type: 'string'},
             mode: {type: 'string', default: 'capture-and-compare'},
             'save-on-failure': {type: 'boolean'},
         },
@@ -103,14 +96,6 @@ config.save = args['save-on-failure'] ? SaveMode.OnFailure : SaveMode.None;
 config.save = args.save ? SaveMode.All : config.save;
 config.mode =
     args.mode === 'capture-and-compare' ? RunnerMode.CaptureAndCompare : RunnerMode.Capture;
-try {
-    const width = args.width ? parseInt(args.width) : null;
-    const height = args.height ? parseInt(args.height) : null;
-    if (width) config.width = width;
-    if (height) config.height = height;
-} catch (e) {
-    logErrorExit('--width and --height must be integers');
-}
 
 try {
     await config.load(positionals[0] ?? CONFIG_NAME);

--- a/src/config.ts
+++ b/src/config.ts
@@ -122,6 +122,9 @@ export class Config {
     /** Browser logs setup. */
     log: LogLevel = LogLevel.Warn & LogLevel.Error;
 
+    /** Maximum number of browser contexts running simultaneously. */
+    maxContexts: number | null = null;
+
     async load(path: string) {
         /* Find all config files to run. */
         const isDirectory = (await stat(path)).isDirectory();

--- a/src/config.ts
+++ b/src/config.ts
@@ -50,6 +50,10 @@ export interface Project {
     path: string;
     name: string;
     timeout: number;
+    /** Screenshot width. Defaults to **480**. */
+    width: number;
+    /** Screenshot height. Defaults to **270**. */
+    height: number;
     scenarios: Scenario[];
 }
 
@@ -109,11 +113,6 @@ export class Config {
     /** Whether to save the screenshots or not.  */
     save: SaveMode = SaveMode.None;
 
-    /** Overriding screenshot width. */
-    width: number | null = null;
-    /** Overriding screenshot height. */
-    height: number | null = null;
-
     /** Web server port. */
     port: number = 8080;
 
@@ -155,6 +154,9 @@ export class Config {
             ? json.scenarios
             : [json.scenarios];
 
+        const width = json.width ?? 480;
+        const height = json.height ?? 270;
+
         const path = resolve(dirname(configPath));
         const name = basename(path);
         const scenarios = (jsonScenarios as ScenarioJson[]).map((s) => ({
@@ -164,7 +166,7 @@ export class Config {
             perPixelTolerance: s.perPixelTolerance ?? 0.1,
         }));
 
-        this.projects.push({timeout, path, name, scenarios});
+        this.projects.push({timeout, path, name, scenarios, width, height});
     }
 
     /**


### PR DESCRIPTION
This MR brings testing ~5 projects from 21s to **6s**

* Use one browser instance per project to test simultaneously
    * Debounce promise until a context is free
* Add `max-contexts` to choose maximum browser instances to CLI
* Move `width` and `height` argument **per-project**. Each project can now choose its testing size since we have one viewport per page.

## TODO Post-Merge
* [ ] Allow to watch a project instead of an event, since events could be missing