### PR TITLE
runner: Add --extensions option to load Chrome extensions

### DIFF
--- a/dist/cli.js
+++ b/dist/cli.js
@@ -21,7 +21,8 @@ function printHelp(summary = false) {
     console.log('\t-o, --output:\tScreenshot output folder. Overwrites references by default\n' +
         '\t--mode:\tCapture and compare (`capture-and-compare`), or capture only (`capture`)\n' +
         '\t--max-contexts:\tMaximum number of parralel browser instances. Up to one per project.\n' +
-        '\t--logs:\tPath to save the browser logs. Logs will be discarded if not provided\n');
+        '\t--logs:\tPath to save the browser logs. Logs will be discarded if not provided\n' +
+        '\t--extensions:\tPaths to Chrome extensions to load\n');
     console.log('\nFLAGS:');
     console.log('\t-h, --help:\tPrints help\n' +
         '\t-w, --watch:\tStart the runner in watch mode for debugging\n' +
@@ -45,6 +46,7 @@ try {
             save: { type: 'boolean', short: 's' },
             logs: { type: 'string' },
             mode: { type: 'string', default: 'capture-and-compare' },
+            extensions: { type: 'string' },
             'max-contexts': { type: 'string' },
             'save-on-failure': { type: 'boolean' },
             'save-difference': { type: 'boolean' },
@@ -68,6 +70,7 @@ config.headless = args.headless ?? false;
 config.output = args.output ? resolve(args.output) : null;
 config.mode =
     args.mode === 'capture-and-compare' ? RunnerMode.CaptureAndCompare : RunnerMode.Capture;
+config.extensions = args.extensions?.split(',') ?? [];
 config.maxContexts = maxContexts && !isNaN(maxContexts) ? maxContexts : null;
 config.save |= args.save ? SaveMode.SuccessAndFailures : SaveMode.None;
 config.save |= args['save-on-failure'] ? SaveMode.Failure : SaveMode.None;

--- a/dist/config.d.ts
+++ b/dist/config.d.ts
@@ -55,14 +55,6 @@ export interface Project {
     scenarios: Scenario[];
 }
 /**
- * Convert the 'readyEvent' entry in a configuration
- * into a generic 'event'.
- *
- * @param event The ready event to convert.
- * @returns An event of the form `wle-scene-ready:${event}`.
- */
-export declare function convertReadyEvent(event: string): string;
-/**
  * Configuration for {@link ScreenshotRunner}.
  */
 export declare class Config {

--- a/dist/config.d.ts
+++ b/dist/config.d.ts
@@ -72,6 +72,8 @@ export declare class Config {
     output: string | null;
     /** Test runner mode. */
     mode: RunnerMode;
+    /** Chrome extensions to load. */
+    extensions: string[];
     /** Bitset to manage screenshots to save. */
     save: number;
     /** Web server port. */

--- a/dist/config.js
+++ b/dist/config.js
@@ -70,6 +70,8 @@ export class Config {
     output = null;
     /** Test runner mode. */
     mode = RunnerMode.CaptureAndCompare;
+    /** Chrome extensions to load. */
+    extensions = [];
     /** Bitset to manage screenshots to save. */
     save = SaveMode.None;
     /** Web server port. */

--- a/dist/config.js
+++ b/dist/config.js
@@ -28,16 +28,6 @@ export var RunnerMode;
     RunnerMode[RunnerMode["CaptureAndCompare"] = 2] = "CaptureAndCompare";
 })(RunnerMode || (RunnerMode = {}));
 /**
- * Convert the 'readyEvent' entry in a configuration
- * into a generic 'event'.
- *
- * @param event The ready event to convert.
- * @returns An event of the form `wle-scene-ready:${event}`.
- */
-export function convertReadyEvent(event) {
-    return `wle-scene-ready:${event}`;
-}
-/**
  * Search for configuration files on the filesystem.
  *
  * @param directory The directory to start the search from.
@@ -116,7 +106,7 @@ export class Config {
         const name = basename(path);
         const scenarios = jsonScenarios.map((s, index) => ({
             index,
-            event: s.event ?? (s.readyEvent ? convertReadyEvent(s.readyEvent) : ''),
+            event: s.event,
             reference: resolve(path, s.reference),
             tolerance: s.tolerance ?? 0.005,
             perPixelTolerance: s.perPixelTolerance ?? 0.1,

--- a/dist/runner.js
+++ b/dist/runner.js
@@ -138,7 +138,13 @@ export class ScreenshotRunner {
             `  ➡️  Watching: ${config.watch}`);
         const server = createServer(this._httpCallback);
         server.listen(config.port);
-        const args = ['--no-sandbox', '--ignore-gpu-blocklist'];
+        const args = [
+            '--no-sandbox',
+            '--ignore-gpu-blocklist',
+            `--disable-extensions-except=${process.cwd()}/${config.extensions.join(',')}`,
+            `--load-extension=${process.cwd()}/${config.extensions.join(',')}`,
+            '--enable-automation',
+        ];
         if (process.platform === 'linux') {
             args.push('--enable-features=Vulkan', '--enable-skia-graphite', '--enable-unsafe-webgpu');
         }
@@ -239,7 +245,9 @@ export class ScreenshotRunner {
         console.log(`\n📷 Capturing scenarios for ${projects.length} project(s)...`);
         const contexts = await Promise.all(Array.from({ length: contextsCount })
             .fill(null)
-            .map((_, i) => i == 0 ? browser.defaultBrowserContext() : browser.createBrowserContext()));
+            .map((_, i) => i == 0
+            ? browser.defaultBrowserContext()
+            : browser.createBrowserContext()));
         const result = Array.from(projects, () => null);
         for (let i = 0; i < projects.length; ++i) {
             let freeContext = -1;

--- a/dist/runner.js
+++ b/dist/runner.js
@@ -288,8 +288,9 @@ export class ScreenshotRunner {
         function onerror(err) {
             error = err;
         }
-        const pages = await browser.pages();
-        const page = pages.length > 0 ? pages[0] : await browser.newPage();
+        /* We can't actually use the 'pages[0]' on the main context, as if it's
+         * the only context it will close the browser when we close it below */
+        const page = await browser.newPage();
         page.on('pageerror', onerror);
         page.on('error', onerror);
         page.on('console', (message) => {

--- a/dist/runner.js
+++ b/dist/runner.js
@@ -328,15 +328,6 @@ export class ScreenshotRunner {
         /* We do not use waitUntil: 'networkidle0' in order to setup
          * the event sink before the project is fully loaded. */
         await page.goto(`http://localhost:${config.port}/index.html`);
-        /* The runner also supports scene loaded events, forwarded in the DOM.
-         * Each time a load event occurs, we convert it to a unique event name and
-         * forward the call to `testScreenshot`. */
-        await page.evaluate(() => {
-            document.addEventListener('wle-scene-ready', function (e) {
-                // @ts-ignore
-                window.testScreenshot(`wle-scene-ready:${e.detail.filename}`);
-            });
-        });
         if (config.watch) {
             await page.waitForNavigation();
         }

--- a/dist/runner.js
+++ b/dist/runner.js
@@ -329,7 +329,7 @@ export class ScreenshotRunner {
          * the event sink before the project is fully loaded. */
         await page.goto(`http://localhost:${config.port}/index.html`);
         if (config.watch) {
-            await page.waitForNavigation();
+            await page.waitForNavigation({ timeout: 0 });
         }
         let time = 0;
         while (error === null && eventCount < count && time < timeout) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,6 +22,8 @@ interface Arguments {
     logs?: string;
     /** Runner mode. */
     mode?: string;
+    /** Chrome extensions to load. */
+    extensions?: string;
     /** Maximum number of parralel browser instances. */
     'max-contexts'?: string;
     /** Save screenshots associated to failed tests. */
@@ -53,7 +55,8 @@ function printHelp(summary = false) {
         '\t-o, --output:\tScreenshot output folder. Overwrites references by default\n' +
             '\t--mode:\tCapture and compare (`capture-and-compare`), or capture only (`capture`)\n' +
             '\t--max-contexts:\tMaximum number of parralel browser instances. Up to one per project.\n' +
-            '\t--logs:\tPath to save the browser logs. Logs will be discarded if not provided\n'
+            '\t--logs:\tPath to save the browser logs. Logs will be discarded if not provided\n' +
+            '\t--extensions:\tPaths to Chrome extensions to load\n'
     );
 
     console.log('\nFLAGS:');
@@ -84,6 +87,7 @@ try {
             save: {type: 'boolean', short: 's'},
             logs: {type: 'string'},
             mode: {type: 'string', default: 'capture-and-compare'},
+            extensions: {type: 'string'},
             'max-contexts': {type: 'string'},
             'save-on-failure': {type: 'boolean'},
             'save-difference': {type: 'boolean'},
@@ -109,6 +113,7 @@ config.headless = args.headless ?? false;
 config.output = args.output ? resolve(args.output) : null;
 config.mode =
     args.mode === 'capture-and-compare' ? RunnerMode.CaptureAndCompare : RunnerMode.Capture;
+config.extensions = args.extensions?.split(',') ?? [];
 config.maxContexts = maxContexts && !isNaN(maxContexts) ? maxContexts : null;
 config.save |= args.save ? SaveMode.SuccessAndFailures : SaveMode.None;
 config.save |= args['save-on-failure'] ? SaveMode.Failure : SaveMode.None;

--- a/src/config.ts
+++ b/src/config.ts
@@ -118,6 +118,9 @@ export class Config {
     /** Test runner mode. */
     mode: RunnerMode = RunnerMode.CaptureAndCompare;
 
+    /** Chrome extensions to load. */
+    extensions: string[] = [];
+
     /** Bitset to manage screenshots to save. */
     save: number = SaveMode.None;
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -65,17 +65,6 @@ export interface Project {
     scenarios: Scenario[];
 }
 
-/**
- * Convert the 'readyEvent' entry in a configuration
- * into a generic 'event'.
- *
- * @param event The ready event to convert.
- * @returns An event of the form `wle-scene-ready:${event}`.
- */
-export function convertReadyEvent(event: string) {
-    return `wle-scene-ready:${event}`;
-}
-
 /** Raw scenario description from the json file. */
 interface ScenarioJson extends Scenario {
     readyEvent: string;
@@ -178,7 +167,7 @@ export class Config {
         const name = basename(path);
         const scenarios = (jsonScenarios as ScenarioJson[]).map((s, index) => ({
             index,
-            event: s.event ?? (s.readyEvent ? convertReadyEvent(s.readyEvent) : ''),
+            event: s.event,
             reference: resolve(path, s.reference),
             tolerance: s.tolerance ?? 0.005,
             perPixelTolerance: s.perPixelTolerance ?? 0.1,

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -172,7 +172,14 @@ export class ScreenshotRunner {
         const server = createServer(this._httpCallback);
         server.listen(config.port);
 
-        const args = ['--no-sandbox', '--ignore-gpu-blocklist'];
+        const args = [
+            '--no-sandbox',
+            '--ignore-gpu-blocklist',
+            `--disable-extensions-except=${process.cwd()}/${config.extensions.join(',')}`,
+            `--load-extension=${process.cwd()}/${config.extensions.join(',')}`,
+            '--enable-automation',
+        ];
+
         if (process.platform === 'linux') {
             args.push(
                 '--enable-features=Vulkan',
@@ -299,7 +306,11 @@ export class ScreenshotRunner {
         const contexts: (BrowserContext | null)[] = await Promise.all(
             Array.from({length: contextsCount})
                 .fill(null)
-                .map((_, i) => i == 0 ? browser.defaultBrowserContext() : browser.createBrowserContext())
+                .map((_, i) =>
+                    i == 0
+                        ? browser.defaultBrowserContext()
+                        : browser.createBrowserContext()
+                )
         );
         const result: Promise<(Uint8Array | Error)[]>[] = Array.from(projects, () => null!);
 

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -413,7 +413,7 @@ export class ScreenshotRunner {
         await page.goto(`http://localhost:${config.port}/index.html`);
 
         if (config.watch) {
-            await page.waitForNavigation();
+            await page.waitForNavigation({timeout: 0});
         }
 
         let time = 0;

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -367,8 +367,9 @@ export class ScreenshotRunner {
             error = err;
         }
 
-        const pages = await browser.pages();
-        const page = pages.length > 0 ? pages[0] : await browser.newPage();
+        /* We can't actually use the 'pages[0]' on the main context, as if it's
+         * the only context it will close the browser when we close it below */
+        const page = await browser.newPage();
         page.on('pageerror', onerror);
         page.on('error', onerror);
         page.on('console', (message: ConsoleMessage) => {

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -411,15 +411,6 @@ export class ScreenshotRunner {
         /* We do not use waitUntil: 'networkidle0' in order to setup
          * the event sink before the project is fully loaded. */
         await page.goto(`http://localhost:${config.port}/index.html`);
-        /* The runner also supports scene loaded events, forwarded in the DOM.
-         * Each time a load event occurs, we convert it to a unique event name and
-         * forward the call to `testScreenshot`. */
-        await page.evaluate(() => {
-            document.addEventListener('wle-scene-ready', function (e) {
-                // @ts-ignore
-                window.testScreenshot(`wle-scene-ready:${e.detail.filename}`);
-            });
-        });
 
         if (config.watch) {
             await page.waitForNavigation();


### PR DESCRIPTION
It won't really work for a list of extensions though so I could rename it to be singular?

There's also a commit to remove the old `wle-scene-ready` event, it doesn't really have a place in a standalone library, + our tests don't even use it anymore cause we directly call `testScreenshot()` directly